### PR TITLE
Fix typo in CSS comment

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -195,7 +195,7 @@ body.dragging .nav-pointer {
 }
 
 /* ----------------------
-  particales js
+  particles js
 ------------------------*/
 #changestyle {
   position: absolute;


### PR DESCRIPTION
## Summary
- correct typo in CSS comment from `particales js` to `particles js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684947e9a8948323a64a6f103f5c91b3